### PR TITLE
Fetch and Present categories as list

### DIFF
--- a/frontend/src/actions/categories.js
+++ b/frontend/src/actions/categories.js
@@ -1,0 +1,13 @@
+import * as api from "../api";
+
+export const GET_CATEGORIES = "GET_CATEGORIES";
+
+export const getCategories = categories => ({
+  type: GET_CATEGORIES,
+  categories
+});
+
+export const handleGetCategories = () => dispatch =>
+  api.getCategories().then(categories => {
+    dispatch(getCategories(categories));
+  });

--- a/frontend/src/components/Category/List.js
+++ b/frontend/src/components/Category/List.js
@@ -1,0 +1,17 @@
+import React from "react";
+import Category from "../../containers/Category";
+
+const List = ({ title, categories }) => (
+  <div>
+    <h2>{title}</h2>
+    <ul>
+      {categories.map(path => (
+        <li key={path}>
+          <Category path={path} />
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default List;

--- a/frontend/src/components/Category/ListItem.js
+++ b/frontend/src/components/Category/ListItem.js
@@ -1,0 +1,8 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+const ListItem = ({ category: { path, name } }) => (
+  <Link to={`/${path}`}>{name}</Link>
+);
+
+export default ListItem;

--- a/frontend/src/components/Home.js
+++ b/frontend/src/components/Home.js
@@ -1,6 +1,11 @@
 import React from "react";
 import List from "./Post/List";
+import Categories from "../containers/Categories";
 
-const Home = ({ postIds }) => <List title={"All Posts"} postIds={postIds} />;
-
+const Home = ({ postIds }) => (
+  <React.Fragment>
+    <List title={"All Posts"} postIds={postIds} />
+    <Categories />
+  </React.Fragment>
+);
 export default Home;

--- a/frontend/src/containers/Categories.js
+++ b/frontend/src/containers/Categories.js
@@ -1,0 +1,22 @@
+import React from "react";
+import { connect } from "react-redux";
+import { handleGetCategories } from "../actions/categories";
+import CategoryList from "../components/Category/List";
+
+class Categories extends React.Component {
+  componentDidMount() {
+    this.props.dispatch(handleGetCategories());
+  }
+
+  render() {
+    return this.props.categories.length > 0 ? (
+      <CategoryList title="Categories" categories={this.props.categories} />
+    ) : null;
+  }
+}
+
+const mapStateToProps = ({ categories }) => ({
+  categories: Object.keys(categories)
+});
+
+export default connect(mapStateToProps)(Categories);

--- a/frontend/src/containers/Category.js
+++ b/frontend/src/containers/Category.js
@@ -1,0 +1,8 @@
+import { connect } from "react-redux";
+import CategoryListItem from "../components/Category/ListItem";
+
+const mapStateToProps = ({ categories }, { path }) => ({
+  category: categories[path]
+});
+
+export default connect(mapStateToProps)(CategoryListItem);

--- a/frontend/src/reducers/categories.js
+++ b/frontend/src/reducers/categories.js
@@ -1,5 +1,16 @@
+import { GET_CATEGORIES } from "../actions/categories";
+
 export default (state = {}, action) => {
   switch (action.type) {
+    case GET_CATEGORIES:
+      const categoryObject = {};
+      action.categories.map(
+        category => (categoryObject[category.path] = category)
+      );
+      return {
+        ...state,
+        ...categoryObject
+      };
     default:
       return state;
   }


### PR DESCRIPTION
## Why?

In order to show all the categories available in the application, I want to fetch them and make it available on the list posts page to be always reachable

## How?

- Fetch categories and save on state
- Since the category is an object with path and name, it was necessary to connect to state just to grab those both properties