### PR TITLE
Clear comment form after submit comment with success

### DIFF
--- a/frontend/src/components/Comment/New.js
+++ b/frontend/src/components/Comment/New.js
@@ -61,14 +61,17 @@ class New extends React.Component {
     body: ""
   };
 
+  clearForm = () => {
+    this.setState({
+      author: "",
+      body: ""
+    });
+  };
+
   handleSubmit = event => {
     event.preventDefault();
-    const {
-      author,
-
-      body
-    } = this.state;
-    this.props.onSubmit({ author, body });
+    const { author, body } = this.state;
+    this.props.onSubmit({ author, body }).then(() => this.clearForm());
   };
 
   handleOnChange = event => {

--- a/frontend/src/components/Comment/New.test.js
+++ b/frontend/src/components/Comment/New.test.js
@@ -57,5 +57,26 @@ describe("New", () => {
 
       expect(wrapper.state("body")).toEqual("This Body");
     });
+
+    it("should clear form after submit", () => {
+      const wrapper = shallow(<New onSubmit={() => Promise.resolve()} />);
+
+      const iTitle = wrapper.find("Input").first();
+      iTitle.simulate("change", {
+        target: { name: "title", value: "This Title" }
+      });
+      const tBody = wrapper.find("Textarea");
+      tBody.simulate("change", {
+        target: { name: "body", value: "This Body" }
+      });
+
+      wrapper
+        .find("Button")
+        .last()
+        .simulate("click");
+
+      expect(iTitle.props().value).toEqual("");
+      expect(tBody.props().value).toEqual("");
+    });
   });
 });


### PR DESCRIPTION
## Why?

In order to have a proper UX behavior
I want to have the fields set to initial state after sending a comment